### PR TITLE
fix: add `identity` algorithm passthrough

### DIFF
--- a/lib/plug_caisson.ex
+++ b/lib/plug_caisson.ex
@@ -63,6 +63,12 @@ defmodule PlugCaisson do
 
   defp fetch_decompressor(conn, types) do
     case Plug.Conn.get_req_header(conn, "content-encoding") do
+      [] ->
+        {:ok, :raw, conn}
+
+      ["identity"] ->
+        {:ok, :raw, conn}
+
       [content_encoding] ->
         case Map.fetch(types, content_encoding) do
           {:ok, {mod, opts}} ->
@@ -80,9 +86,6 @@ defmodule PlugCaisson do
           _ ->
             {:error, :not_supported}
         end
-
-      [] ->
-        {:ok, :raw, conn}
     end
   end
 


### PR DESCRIPTION
[RFC 9110][] states that `identity` algorithm should not be included
in `Content-Encoding` header as it is reserved for `Accept-Encoding`,
but just to comply with [Postel's law of robustness][postel law] I think
we should include that as well. It do not imposes any additional cost
for us, but could help with some clients which implement HTTP
incorrectly.

[RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.4-5
[postel law]: https://datatracker.ietf.org/doc/html/rfc761#section-2.10
