### PR TITLE
chore: simplify ci checks

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -5,7 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
+    paths:
+      - lib/**
+      - test/**
+      - mix.exs
 jobs:
   build:
     name: Build and test
@@ -13,7 +16,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ['24', '25', '26']
-        elixir_version: ['1.15', '1.16']
+        elixir_version: ['1.15']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir
@@ -32,4 +35,4 @@ jobs:
     - name: Install dependencies
       run: mix do deps.get, deps.compile
     - name: Run tests
-      run: mix test ${{ matrix.suite }}
+      run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -5,10 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths:
-      - lib/**
-      - test/**
-      - mix.exs
+    
 jobs:
   build:
     name: Build and test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,12 +13,7 @@ jobs:
     strategy:
       matrix:
         otp_version: ['24', '25', '26']
-        elixir_version: ['1.15', '1.14.3', '1.13.4']
-        include:
-        - otp_version: '23.3'
-          elixir_version: '1.11.3'
-        - otp_version: '24.2'
-          elixir_version: '1.12.3'
+        elixir_version: ['1.15', '1.16']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Elixir

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,9 +13,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        otp-version: '24.0'
-        elixir-version: '1.12.1'
-        rebar3-version: '3.15.2'
+        version-file: .tool-versions
+        version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:
@@ -33,9 +32,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        otp-version: '24.0'
-        elixir-version: '1.12.1'
-        rebar3-version: '3.15.2'
+        version-file: .tool-versions
+        version-type: strict
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.15.5-otp-26
+erlang 26.1.2


### PR DESCRIPTION
This adds in `.tool-versions`, removes unnecessary matrix checks.