### PR TITLE
fix: failing tests from missing function header match

### DIFF
--- a/lib/plug_caisson.ex
+++ b/lib/plug_caisson.ex
@@ -94,7 +94,7 @@ defmodule PlugCaisson do
 
   defp try_decompress(data, :raw, _), do: {:ok, data}
 
-  defp try_decompress(data, {mod, state}), do: mod.process(state, data)
+  defp try_decompress(data, {mod, state}, opts), do: mod.process(state, data, opts)
 
   defp set_state(conn, mod, state) do
     conn


### PR DESCRIPTION
Fixes failing tests due to missing function header match for try_decompress/3