### PR TITLE
fix: prevent deinit callback from being called twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add `:plug_caisson` to dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:plug_caisson, "~> 0.1.0"},
+    {:plug_caisson, "~> 0.1.1"},
     # optional, for brotli support
     {:brotli, "~> 0.3.2"},
     # optional, for zstd support
@@ -31,10 +31,8 @@ And then add `{PlugCaisson, :read_body, []}` as a `:body_reader` to your `Plug.P
 ```elixir
 plug Plug.Parsers,
   parsers: [:urlencoded, :json],
-  body_reader: {PlugCaisson, :read_body, [
-    # optional, max decompressed size, defaults to 8_000_000 bytes
-    length: 8_000_000
-  ]}
+  body_reader: {PlugCaisson, :read_body, []},
+  length: 8_000_000
 ```
 
 All options passed to the plug are forwarded to [`Plug.Conn.read_body/2`](https://hexdocs.pm/plug/Plug.Conn.html#read_body/2).

--- a/lib/plug_caisson.ex
+++ b/lib/plug_caisson.ex
@@ -100,8 +100,14 @@ defmodule PlugCaisson do
     conn
     |> Plug.Conn.put_private(__MODULE__, {mod, state})
     |> Plug.Conn.register_before_send(fn conn ->
-      {mod, state} = conn.private[__MODULE__]
-      mod.deinit(state)
+      case conn.private[__MODULE__] do
+        {mod, state} ->
+          mod.deinit(state)
+          Plug.Conn.put_private(conn, __MODULE__, nil)
+
+        nil ->
+          conn
+      end
     end)
   end
 end

--- a/lib/plug_caisson/brotli.ex
+++ b/lib/plug_caisson/brotli.ex
@@ -32,7 +32,7 @@ defmodule PlugCaisson.Brotli do
     def deinit(_state), do: :ok
 
     @impl true
-    def process(decoder, data) do
+    def process(_state, _data, _opts) do
       {:error, :not_supported}
     end
   end

--- a/lib/plug_caisson/zlib.ex
+++ b/lib/plug_caisson/zlib.ex
@@ -23,7 +23,7 @@ defmodule PlugCaisson.Zlib do
   @impl true
   def init(opts) do
     z = :zlib.open()
-    :zlib.inflateInit(z, window_bits(opts))
+    :ok = :zlib.inflateInit(z, window_bits(opts))
 
     {:ok, z}
   end

--- a/lib/plug_caisson/zstandard.ex
+++ b/lib/plug_caisson/zstandard.ex
@@ -29,7 +29,7 @@ defmodule PlugCaisson.Zstandard do
     def deinit(_state), do: :ok
 
     @impl true
-    def process(_state, data) do
+    def process(_state, _data, _opts) do
       {:error, :not_supported}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PlugCaisson.MixProject do
   def project do
     [
       app: :plug_caisson,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -36,6 +36,7 @@ defmodule PlugCaisson.MixProject do
       {:plug, "~> 1.15"},
       {:brotli, "~> 0.3.2", optional: true},
       {:ezstd, "~> 1.0", optional: true},
+      {:jason, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev]},
       {:credo, ">= 0.0.0", only: [:dev, :test]}
     ]

--- a/test/plug_caisson_test.exs
+++ b/test/plug_caisson_test.exs
@@ -1,7 +1,52 @@
 defmodule PlugCaissonTest do
   use ExUnit.Case, async: true
+  use Plug.Test
 
   @subject PlugCaisson
 
   doctest @subject
+
+  defmodule DumbAlgo do
+    @behaviour PlugCaisson
+
+    @impl true
+    def init(opts), do: {:ok, opts[:pid] || self()}
+
+    @impl true
+    def deinit(pid), do: send(pid, :deinit)
+
+    @impl true
+    def process(_, data, _opts), do: {:ok, data}
+  end
+
+  defmodule SimplePipeline do
+    use Plug.Builder
+
+    plug(Plug.Parsers,
+      parsers: [:urlencoded, :json],
+      json_decoder: Jason,
+      body_reader: {PlugCaisson, :read_body, []},
+      algorithms: %{
+        "dumb" => {PlugCaissonTest.DumbAlgo, []}
+      }
+    )
+
+    plug(:handle)
+
+    defp handle(conn, []) do
+      send_resp(conn, 200, Jason.encode!(conn.body_params))
+    end
+  end
+
+  test "deinit callback is called" do
+    assert {200, _, body} =
+             conn(:post, "/", Jason.encode!(%{"hello" => "world"}))
+             |> put_req_header("content-type", "application/json")
+             |> put_req_header("content-encoding", "dumb")
+             |> SimplePipeline.call([])
+             |> sent_resp()
+
+    assert {:ok, %{"hello" => "world"}} == Jason.decode(body)
+    assert_received :deinit
+  end
 end


### PR DESCRIPTION
This also fixes return value from `register_before_send/2` callback. By the API it should always return `Plug.Conn.t()` while we were returning `:ok`.
