### PR TITLE
fix: RequestTooLargeError for gzip chunking

### DIFF
--- a/lib/plug_caisson/zlib.ex
+++ b/lib/plug_caisson/zlib.ex
@@ -63,10 +63,10 @@ defmodule PlugCaisson.Zlib do
   end
 
   defp chunked_inflate({:continue, output}, z, acc, length) do
-    if length - IO.iodata_length(output) <= 0 do
+    if length - IO.iodata_length(output) >= 0 do
       z
       |> :zlib.safeInflate([])
-      |> chunked_inflate(z, [output | acc], length - byte_size(output))
+      |> chunked_inflate(z, [output | acc], length - IO.iodata_length(output))
     else
       {:more, Enum.reverse([output | acc])}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PlugCaisson.MixProject do
   def project do
     [
       app: :plug_caisson,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/plug_caisson_test.exs
+++ b/test/plug_caisson_test.exs
@@ -7,6 +7,7 @@ defmodule PlugCaissonTest do
   doctest @subject
 
   defmodule DumbAlgo do
+    @moduledoc false
     @behaviour PlugCaisson
 
     @impl true
@@ -38,6 +39,23 @@ defmodule PlugCaissonTest do
     end
   end
 
+  defmodule DefaultPipeline do
+    @moduledoc false
+    use Plug.Builder
+
+    plug(Plug.Parsers,
+      parsers: [:urlencoded, :json],
+      json_decoder: Jason,
+      body_reader: {PlugCaisson, :read_body, []}
+    )
+
+    plug(:handle)
+
+    defp handle(conn, []) do
+      send_resp(conn, 200, Jason.encode!(conn.body_params))
+    end
+  end
+
   test "deinit callback is called" do
     assert {200, _, body} =
              conn(:post, "/", Jason.encode!(%{"hello" => "world"}))
@@ -48,5 +66,19 @@ defmodule PlugCaissonTest do
 
     assert {:ok, %{"hello" => "world"}} == Jason.decode(body)
     assert_received :deinit
+  end
+
+  test "gzip" do
+    value = for _i <- 1..2000, do: %{"hello" => "world"}
+    payload = :zlib.gzip(Jason.encode!(value))
+
+    assert {200, _, body} =
+             conn(:post, "/", payload)
+             |> put_req_header("content-type", "application/json")
+             |> put_req_header("content-encoding", "gzip")
+             |> DefaultPipeline.call([])
+             |> sent_resp()
+
+    assert {:ok, %{"_json" => [%{"hello" => "world"} | _]}} = Jason.decode(body)
   end
 end


### PR DESCRIPTION
Chunking logic was resulting in errors when gzipped payload was large, as there was never any further iteration beyond the first.

```
    ** (Plug.Parsers.RequestTooLargeError) the request is too large. If you are willing to process larger requests, please give a :length to Plug.Parsers
 ```
 