### PR TITLE
test: add tests that passes data through Plug.Parsers

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:stream_data],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/lib/plug_caisson.ex
+++ b/lib/plug_caisson.ex
@@ -89,6 +89,9 @@ defmodule PlugCaisson do
           _ ->
             {:error, :not_supported}
         end
+
+      [_ | _] ->
+        {:error, :not_supported}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,9 @@ defmodule PlugCaisson.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
+      test_coverage: [
+        ignore_modules: [TestUtils]
+      ],
       docs: [
         extras: ~w[README.md],
         main: "readme",
@@ -38,7 +41,8 @@ defmodule PlugCaisson.MixProject do
       {:ezstd, "~> 1.0", optional: true},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev]},
-      {:credo, ">= 0.0.0", only: [:dev, :test]}
+      {:credo, ">= 0.0.0", only: [:dev, :test]},
+      {:stream_data, "~> 0.6.0", only: [:dev, :test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -14,5 +14,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "plug": {:hex, :plug, "1.15.2", "94cf1fa375526f30ff8770837cb804798e0045fd97185f0bb9e5fcd858c792a3", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2 or ~> 2.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "02731fa0c2dcb03d8d21a1d941bdbbe99c2946c0db098eee31008e04c6283615"},
   "plug_crypto": {:hex, :plug_crypto, "2.0.0", "77515cc10af06645abbfb5e6ad7a3e9714f805ae118fa1a70205f80d2d70fe73", [:mix], [], "hexpm", "53695bae57cc4e54566d993eb01074e4d894b65a3766f1c43e2c61a1b0f45ea9"},
+  "stream_data": {:hex, :stream_data, "0.6.0", "e87a9a79d7ec23d10ff83eb025141ef4915eeb09d4491f79e52f2562b73e5f47", [:mix], [], "hexpm", "b92b5031b650ca480ced047578f1d57ea6dd563f5b57464ad274718c9c29501c"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }

--- a/test/plug_caisson/brotli_test.exs
+++ b/test/plug_caisson/brotli_test.exs
@@ -1,5 +1,7 @@
 defmodule PlugCaisson.BrotliTest do
   use ExUnit.Case, async: true
+  use Plug.Test
+  use ExUnitProperties
 
   import TestUtils
 
@@ -25,6 +27,44 @@ defmodule PlugCaisson.BrotliTest do
     conn = post(data, @content_type)
 
     assert raw == Enum.join(body_stream(conn, length: 10))
+  end
+
+  property "data is returned as is" do
+    check all raw <- binary() do
+      data = compress(raw)
+      conn = post(data, @content_type)
+
+      assert raw == Enum.join(body_stream(conn))
+    end
+  end
+
+  property "length can be set to custom value" do
+    check all raw <- binary(),
+              length <- positive_integer() do
+      data = compress(raw)
+      conn = post(data, @content_type)
+
+      assert raw == Enum.join(body_stream(conn, length: length))
+    end
+  end
+
+  test "Plug.Parser" do
+    pipeline =
+      pipeline([
+        {Plug.Parsers,
+         parsers: [:json], json_decoder: Jason, body_reader: {PlugCaisson, :read_body, []}},
+        {&echo_plug/2, encoder: &Jason.encode!/1}
+      ])
+
+    value = for _i <- 1..2000, do: %{"hello" => "world"}
+    payload = compress(Jason.encode!(value))
+
+    assert {200, _, body} =
+             post({"application/json", payload}, @content_type)
+             |> pipeline.()
+             |> sent_resp()
+
+    assert {:ok, %{"_json" => [%{"hello" => "world"} | _]}} = Jason.decode(body)
   end
 
   describe "corpus tests" do

--- a/test/plug_caisson/deflate_test.exs
+++ b/test/plug_caisson/deflate_test.exs
@@ -1,5 +1,7 @@
 defmodule PlugCaisson.DeflateTest do
   use ExUnit.Case, async: true
+  use Plug.Test
+  use ExUnitProperties
 
   import TestUtils
 
@@ -22,6 +24,44 @@ defmodule PlugCaisson.DeflateTest do
     conn = post(data, @content_type)
 
     assert raw == Enum.join(body_stream(conn, length: 10))
+  end
+
+  property "data is returned as is" do
+    check all raw <- binary() do
+      data = compress(raw)
+      conn = post(data, @content_type)
+
+      assert raw == Enum.join(body_stream(conn))
+    end
+  end
+
+  property "length can be set to custom value" do
+    check all raw <- binary(),
+              length <- positive_integer() do
+      data = compress(raw)
+      conn = post(data, @content_type)
+
+      assert raw == Enum.join(body_stream(conn, length: length))
+    end
+  end
+
+  test "Plug.Parser" do
+    pipeline =
+      pipeline([
+        {Plug.Parsers,
+         parsers: [:json], json_decoder: Jason, body_reader: {PlugCaisson, :read_body, []}},
+        {&echo_plug/2, encoder: &Jason.encode!/1}
+      ])
+
+    value = for _i <- 1..2000, do: %{"hello" => "world"}
+    payload = compress(Jason.encode!(value))
+
+    assert {200, _, body} =
+             post({"application/json", payload}, @content_type)
+             |> pipeline.()
+             |> sent_resp()
+
+    assert {:ok, %{"_json" => [%{"hello" => "world"} | _]}} = Jason.decode(body)
   end
 
   describe "corpus tests" do

--- a/test/plug_caisson/identity_test.exs
+++ b/test/plug_caisson/identity_test.exs
@@ -1,13 +1,13 @@
-defmodule PlugCaisson.GzipTest do
+defmodule PlugCaisson.IdentityTest do
   use ExUnit.Case, async: true
   use Plug.Test
   use ExUnitProperties
 
   import TestUtils
 
-  @content_type "gzip"
+  @content_type "identity"
 
-  defp compress(data), do: :zlib.gzip(data)
+  defp compress(data), do: data
 
   test "simple test" do
     raw = "Chrzęszczyrzewoszyckie chrząszcze chrobotliwie chrzeszczą w haszczach"
@@ -43,13 +43,6 @@ defmodule PlugCaisson.GzipTest do
 
       assert raw == Enum.join(body_stream(conn, length: length))
     end
-  end
-
-  test "when hit lenght limit it do not decompress further, even with zipbomb" do
-    data = File.read!(Path.join(__DIR__, "gzip_test/bomb.gz"))
-    conn = post(data, @content_type)
-
-    assert {:more, _, _} = PlugCaisson.read_body(conn)
   end
 
   test "Plug.Parser" do

--- a/test/plug_caisson/no_header_test.exs
+++ b/test/plug_caisson/no_header_test.exs
@@ -1,13 +1,13 @@
-defmodule PlugCaisson.GzipTest do
+defmodule PlugCaisson.NoHeaderTest do
   use ExUnit.Case, async: true
   use Plug.Test
   use ExUnitProperties
 
   import TestUtils
 
-  @content_type "gzip"
+  @content_type nil
 
-  defp compress(data), do: :zlib.gzip(data)
+  defp compress(data), do: data
 
   test "simple test" do
     raw = "Chrzęszczyrzewoszyckie chrząszcze chrobotliwie chrzeszczą w haszczach"
@@ -43,13 +43,6 @@ defmodule PlugCaisson.GzipTest do
 
       assert raw == Enum.join(body_stream(conn, length: length))
     end
-  end
-
-  test "when hit lenght limit it do not decompress further, even with zipbomb" do
-    data = File.read!(Path.join(__DIR__, "gzip_test/bomb.gz"))
-    conn = post(data, @content_type)
-
-    assert {:more, _, _} = PlugCaisson.read_body(conn)
   end
 
   test "Plug.Parser" do

--- a/test/plug_caisson/zstd_test.exs
+++ b/test/plug_caisson/zstd_test.exs
@@ -1,5 +1,7 @@
 defmodule PlugCaisson.ZstdTest do
   use ExUnit.Case, async: true
+  use Plug.Test
+  use ExUnitProperties
 
   import TestUtils
 
@@ -23,6 +25,45 @@ defmodule PlugCaisson.ZstdTest do
     conn = post(data, @content_type)
 
     assert raw == Enum.join(body_stream(conn, length: 10))
+  end
+
+  property "data is returned as is" do
+    check all raw <- binary() do
+      data = compress(raw)
+      conn = post(data, @content_type)
+
+      assert raw == Enum.join(body_stream(conn))
+    end
+  end
+
+  @tag skip: "ezstd currently do not support streaming decompression"
+  property "length can be set to custom value" do
+    check all raw <- binary(),
+              length <- positive_integer() do
+      data = compress(raw)
+      conn = post(data, @content_type)
+
+      assert raw == Enum.join(body_stream(conn, length: length))
+    end
+  end
+
+  test "Plug.Parser" do
+    pipeline =
+      pipeline([
+        {Plug.Parsers,
+         parsers: [:json], json_decoder: Jason, body_reader: {PlugCaisson, :read_body, []}},
+        {&echo_plug/2, encoder: &Jason.encode!/1}
+      ])
+
+    value = for _i <- 1..2000, do: %{"hello" => "world"}
+    payload = compress(Jason.encode!(value))
+
+    assert {200, _, body} =
+             post({"application/json", payload}, @content_type)
+             |> pipeline.()
+             |> sent_resp()
+
+    assert {:ok, %{"_json" => [%{"hello" => "world"} | _]}} = Jason.decode(body)
   end
 
   describe "corpus tests" do

--- a/test/plug_caisson_test.exs
+++ b/test/plug_caisson_test.exs
@@ -2,6 +2,8 @@ defmodule PlugCaissonTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  import TestUtils
+
   @subject PlugCaisson
 
   doctest @subject
@@ -20,65 +22,27 @@ defmodule PlugCaissonTest do
     def process(_, data, _opts), do: {:ok, data}
   end
 
-  defmodule SimplePipeline do
-    use Plug.Builder
-
-    plug(Plug.Parsers,
-      parsers: [:urlencoded, :json],
-      json_decoder: Jason,
-      body_reader: {PlugCaisson, :read_body, []},
-      algorithms: %{
-        "dumb" => {PlugCaissonTest.DumbAlgo, []}
-      }
-    )
-
-    plug(:handle)
-
-    defp handle(conn, []) do
-      send_resp(conn, 200, Jason.encode!(conn.body_params))
-    end
-  end
-
-  defmodule DefaultPipeline do
-    @moduledoc false
-    use Plug.Builder
-
-    plug(Plug.Parsers,
-      parsers: [:urlencoded, :json],
-      json_decoder: Jason,
-      body_reader: {PlugCaisson, :read_body, []}
-    )
-
-    plug(:handle)
-
-    defp handle(conn, []) do
-      send_resp(conn, 200, Jason.encode!(conn.body_params))
-    end
-  end
-
   test "deinit callback is called" do
+    pipeline =
+      pipeline([
+        {Plug.Parsers,
+         parsers: [:urlencoded, :json],
+         json_decoder: Jason,
+         body_reader: {PlugCaisson, :read_body, []},
+         algorithms: %{
+           "dumb" => {PlugCaissonTest.DumbAlgo, []}
+         }},
+        {&echo_plug/2, encoder: &Jason.encode!/1}
+      ])
+
     assert {200, _, body} =
              conn(:post, "/", Jason.encode!(%{"hello" => "world"}))
              |> put_req_header("content-type", "application/json")
              |> put_req_header("content-encoding", "dumb")
-             |> SimplePipeline.call([])
+             |> pipeline.()
              |> sent_resp()
 
     assert {:ok, %{"hello" => "world"}} == Jason.decode(body)
     assert_received :deinit
-  end
-
-  test "gzip" do
-    value = for _i <- 1..2000, do: %{"hello" => "world"}
-    payload = :zlib.gzip(Jason.encode!(value))
-
-    assert {200, _, body} =
-             conn(:post, "/", payload)
-             |> put_req_header("content-type", "application/json")
-             |> put_req_header("content-encoding", "gzip")
-             |> DefaultPipeline.call([])
-             |> sent_resp()
-
-    assert {:ok, %{"_json" => [%{"hello" => "world"} | _]}} = Jason.decode(body)
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -3,15 +3,39 @@ defmodule TestUtils do
 
   use Plug.Test
 
-  def post(body, content_encoding \\ nil) do
-    conn = conn(:post, "/", body)
-
-    if content_encoding do
-      put_req_header(conn, "content-encoding", content_encoding)
-    else
-      conn
-    end
+  def pipeline(plugs) do
+    fn conn -> Enum.reduce(plugs, conn, &call_plug/2) end
   end
+
+  defp call_plug({mod, opts}, conn) when is_atom(mod) do
+    opts = mod.init(opts)
+    mod.call(conn, opts)
+  end
+
+  defp call_plug({fun, opts}, conn) when is_function(fun, 2) do
+    fun.(conn, opts)
+  end
+
+  def echo_plug(conn, opts) do
+    encoder = opts[:encoder] || (&Function.identity/1)
+    code = opts[:code] || 200
+
+    send_resp(conn, code, encoder.(conn.body_params))
+  end
+
+  def post({type, body}, content_encoding) do
+    conn(:post, "/", body)
+    |> put_req_header("content-type", type)
+    |> do_post(content_encoding)
+  end
+
+  def post(body, content_encoding) do
+    conn(:post, "/", body)
+    |> do_post(content_encoding)
+  end
+
+  defp do_post(conn, nil), do: conn
+  defp do_post(conn, ce), do: put_req_header(conn, "content-encoding", ce)
 
   def body_stream(conn, opts \\ []) do
     Stream.unfold(conn, fn conn ->
@@ -31,15 +55,5 @@ defmodule TestUtils do
 
   def corpus(name) do
     Map.fetch!(corpus(), name)
-  end
-
-  def binary_chunks(bin, width) do
-    case bin do
-      <<chunk::binary-size(width)>> <> rest ->
-        [chunk | binary_chunks(rest, width)]
-
-      last ->
-        [last]
-    end
   end
 end

--- a/test/support/test_utils.ex
+++ b/test/support/test_utils.ex
@@ -17,7 +17,13 @@ defmodule TestUtils do
   end
 
   def echo_plug(conn, opts) do
-    encoder = opts[:encoder] || (&Function.identity/1)
+    encoder =
+      opts[:encoder] ||
+        fn _ ->
+          {:ok, data, _} = Plug.Conn.read_body(conn)
+          data
+        end
+
     code = opts[:code] || 200
 
     send_resp(conn, code, encoder.(conn.body_params))


### PR DESCRIPTION
This also adds tests for `identity` content encoding and for situation
when there is no content encoding header at all.
