### PR TITLE
Add links to source in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,13 @@
 defmodule PlugCaisson.MixProject do
   use Mix.Project
 
+  @version "0.2.1"
+  @github_url "https://github.com/supabase/plug_caisson"
+
   def project do
     [
       app: :plug_caisson,
-      version: "0.2.1",
+      version: @version,
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -16,6 +19,8 @@ defmodule PlugCaisson.MixProject do
       docs: [
         extras: ~w[README.md],
         main: "readme",
+        source_url: @github_url,
+        source_ref: "v#{@version}",
         groups_for_modules: [
           Algorithms: [~r/PlugCaisson\./]
         ]
@@ -50,7 +55,7 @@ defmodule PlugCaisson.MixProject do
     [
       description: "Compressed Body Reader",
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/supabase/plug_caisson"}
+      links: %{"GitHub" => @github_url}
     ]
   end
 end


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows to easily jump to the source from hex docs. 

## What is the current behavior?

No link to source in [docs](https://hexdocs.pm/plug_caisson/PlugCaisson.html)

## What is the new behavior?

![Screenshot 2025-05-06 at 17 45 11](https://github.com/user-attachments/assets/28d3f181-0ce9-4972-8bc4-28e91687c63e)

Clicking the `</>` link jumps to https://github.com/supabase/plug_caisson/blob/v0.2.1/lib/plug_caisson.ex#L1